### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ def _warn_node(self, msg, node):
     http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
     """
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        self._warnfunc(msg, '{0!s}:{1!s}'.format(*get_source_line(node)))
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/examples/dynamic_requirements.py
+++ b/examples/dynamic_requirements.py
@@ -32,7 +32,7 @@ class Config(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget('/tmp/Config_%d.txt' % self.seed)
+        return luigi.LocalTarget('/tmp/Config_{0:d}.txt'.format(self.seed))
 
     def run(self):
         time.sleep(5)
@@ -55,12 +55,12 @@ class Data(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget('/tmp/Data_%d.txt' % self.magic_number)
+        return luigi.LocalTarget('/tmp/Data_{0:d}.txt'.format(self.magic_number))
 
     def run(self):
         time.sleep(1)
         with self.output().open('w') as f:
-            f.write('%s' % self.magic_number)
+            f.write('{0!s}'.format(self.magic_number))
 
 
 class Dynamic(luigi.Task):
@@ -74,7 +74,7 @@ class Dynamic(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget('/tmp/Dynamic_%d.txt' % self.seed)
+        return luigi.LocalTarget('/tmp/Dynamic_{0:d}.txt'.format(self.seed))
 
     def run(self):
         # This could be done using regular requires method

--- a/examples/elasticsearch_index.py
+++ b/examples/elasticsearch_index.py
@@ -44,7 +44,7 @@ class FakeDocuments(luigi.Task):
         today = datetime.date.today()
         with self.output().open('w') as output:
             for i in range(5):
-                output.write(json.dumps({'_id': i, 'text': 'Hi %s' % i,
+                output.write(json.dumps({'_id': i, 'text': 'Hi {0!s}'.format(i),
                                          'date': str(today)}))
                 output.write('\n')
 
@@ -56,7 +56,7 @@ class FakeDocuments(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget(path='/tmp/_docs-%s.ldj' % self.date)
+        return luigi.LocalTarget(path='/tmp/_docs-{0!s}.ldj'.format(self.date))
 
 
 class IndexDocuments(CopyToIndex):

--- a/examples/execution_summary_example.py
+++ b/examples/execution_summary_example.py
@@ -91,7 +91,7 @@ class Bar(luigi.Task):
         self.output().open('w').close()
 
     def output(self):
-        return luigi.LocalTarget('/tmp/bar/%d' % self.num)
+        return luigi.LocalTarget('/tmp/bar/{0:d}'.format(self.num))
 
 
 class DateTask(luigi.Task):

--- a/examples/foo.py
+++ b/examples/foo.py
@@ -50,7 +50,7 @@ class Bar(luigi.Task):
         :rtype: object (:py:class:`~luigi.target.Target`)
         """
         time.sleep(1)
-        return luigi.LocalTarget('/tmp/bar/%d' % self.num)
+        return luigi.LocalTarget('/tmp/bar/{0:d}'.format(self.num))
 
 
 if __name__ == "__main__":

--- a/examples/foo_complex.py
+++ b/examples/foo_complex.py
@@ -66,7 +66,7 @@ class Bar(luigi.Task):
        :rtype: object (:py:class:`~luigi.target.Target`)
        """
         time.sleep(1)
-        return luigi.LocalTarget('/tmp/bar/%d' % self.num)
+        return luigi.LocalTarget('/tmp/bar/{0:d}'.format(self.num))
 
 
 if __name__ == "__main__":

--- a/examples/spark_als.py
+++ b/examples/spark_als.py
@@ -43,7 +43,7 @@ class UserItemMatrix(luigi.Task):
         w = self.output().open('w')
         for user in range(self.data_size):
             track = int(random.random() * self.data_size)
-            w.write('%d\%d\%f' % (user, track, 1.0))
+            w.write('{0:d}\{1:d}\{2:f}'.format(user, track, 1.0))
         w.close()
 
     def output(self):

--- a/examples/top_artists.py
+++ b/examples/top_artists.py
@@ -156,7 +156,7 @@ class AggregateArtistsHadoop(luigi.contrib.hadoop.JobTask):
         :rtype: object (:py:class:`luigi.target.Target`)
         """
         return luigi.contrib.hdfs.HdfsTarget(
-            "data/artist_streams_%s.tsv" % self.date_interval,
+            "data/artist_streams_{0!s}.tsv".format(self.date_interval),
             format=luigi.contrib.hdfs.PlainDir
         )
 
@@ -223,7 +223,7 @@ class Top10Artists(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget("data/top_artists_%s.tsv" % self.date_interval)
+        return luigi.LocalTarget("data/top_artists_{0!s}.tsv".format(self.date_interval))
 
     def run(self):
         top_10 = nlargest(10, self._input_iterator())

--- a/examples/wordcount.py
+++ b/examples/wordcount.py
@@ -58,7 +58,7 @@ class WordCount(luigi.Task):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.LocalTarget('/var/tmp/text-count/%s' % self.date_interval)
+        return luigi.LocalTarget('/var/tmp/text-count/{0!s}'.format(self.date_interval))
 
     def run(self):
         """
@@ -76,5 +76,5 @@ class WordCount(luigi.Task):
         # output data
         f = self.output().open('w')
         for word, count in six.iteritems(count):
-            f.write("%s\t%d\n" % (word, count))
+            f.write("{0!s}\t{1:d}\n".format(word, count))
         f.close()  # WARNING: file system operations are atomic therefore if you don't close the file you lose all data

--- a/examples/wordcount_hadoop.py
+++ b/examples/wordcount_hadoop.py
@@ -75,7 +75,7 @@ class WordCount(luigi.contrib.hadoop.JobTask):
         :return: the target output for this task.
         :rtype: object (:py:class:`luigi.target.Target`)
         """
-        return luigi.contrib.hdfs.HdfsTarget('/tmp/text-count/%s' % self.date_interval)
+        return luigi.contrib.hdfs.HdfsTarget('/tmp/text-count/{0!s}'.format(self.date_interval))
 
     def mapper(self, line):
         for word in line.strip().split():

--- a/luigi/contrib/bigquery.py
+++ b/luigi/contrib/bigquery.py
@@ -499,7 +499,7 @@ class BigqueryLoadTask(MixinBigqueryBulkComplete, luigi.Task):
 
     def run(self):
         output = self.output()
-        assert isinstance(output, BigqueryTarget), 'Output should be a bigquery target, not %s' % (output)
+        assert isinstance(output, BigqueryTarget), 'Output should be a bigquery target, not {0!s}'.format((output))
 
         bq_client = output.client
 
@@ -569,7 +569,7 @@ class BigqueryRunQueryTask(MixinBigqueryBulkComplete, luigi.Task):
 
     def run(self):
         output = self.output()
-        assert isinstance(output, BigqueryTarget), 'Output should be a bigquery target, not %s' % (output)
+        assert isinstance(output, BigqueryTarget), 'Output should be a bigquery target, not {0!s}'.format((output))
 
         query = self.query
         assert query, 'No query was provided'
@@ -619,7 +619,7 @@ class BigqueryCreateViewTask(luigi.Task):
 
     def complete(self):
         output = self.output()
-        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not %s' % (output)
+        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not {0!s}'.format((output))
 
         if not output.exists():
             return False
@@ -629,7 +629,7 @@ class BigqueryCreateViewTask(luigi.Task):
 
     def run(self):
         output = self.output()
-        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not %s' % (output)
+        assert isinstance(output, BigqueryTarget), 'Output must be a bigquery target, not {0!s}'.format((output))
 
         view = self.view
         assert view, 'No view was provided'

--- a/luigi/contrib/esindex.py
+++ b/luigi/contrib/esindex.py
@@ -159,7 +159,7 @@ class ElasticsearchTarget(luigi.Target):
         """
         Generate an id for the indicator document.
         """
-        params = '%s:%s:%s' % (self.index, self.doc_type, self.update_id)
+        params = '{0!s}:{1!s}:{2!s}'.format(self.index, self.doc_type, self.update_id)
         return hashlib.sha1(params.encode('utf-8')).hexdigest()
 
     def touch(self):

--- a/luigi/contrib/ftp.py
+++ b/luigi/contrib/ftp.py
@@ -274,11 +274,11 @@ class RemoteFileSystem(luigi.target.FileSystem):
 
         # random file name
         if atomic:
-            tmp_path = folder + os.sep + 'luigi-tmp-%09d' % random.randrange(0, 1e10)
+            tmp_path = folder + os.sep + 'luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
         else:
             tmp_path = normpath
 
-        self.conn.storbinary('STOR %s' % tmp_path, open(local_path, 'rb'))
+        self.conn.storbinary('STOR {0!s}'.format(tmp_path), open(local_path, 'rb'))
 
         if atomic:
             self.conn.rename(tmp_path, normpath)
@@ -292,7 +292,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
         if folder and not os.path.exists(folder):
             os.makedirs(folder)
 
-        tmp_local_path = local_path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
+        tmp_local_path = local_path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
 
         # download file
         self._connect()
@@ -310,7 +310,7 @@ class RemoteFileSystem(luigi.target.FileSystem):
         self.conn.get(path, tmp_local_path)
 
     def _ftp_get(self, path, tmp_local_path):
-        self.conn.retrbinary('RETR %s' % path, open(tmp_local_path, 'wb').write)
+        self.conn.retrbinary('RETR {0!s}'.format(path), open(tmp_local_path, 'wb').write)
 
 
 class AtomicFtpFile(luigi.target.AtomicLocalFile):
@@ -382,7 +382,7 @@ class RemoteTarget(luigi.target.FileSystemTarget):
 
         elif mode == 'r':
             temp_dir = os.path.join(tempfile.gettempdir(), 'luigi-contrib-ftp')
-            self.__tmp_path = temp_dir + '/' + self.path.lstrip('/') + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
+            self.__tmp_path = temp_dir + '/' + self.path.lstrip('/') + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
             # download file to local
             self._fs.get(self.path, self.__tmp_path)
 

--- a/luigi/contrib/hadoop_jar.py
+++ b/luigi/contrib/hadoop_jar.py
@@ -47,7 +47,7 @@ def fix_paths(job):
                 args.append(x.path)
             else:  # output
                 x_path_no_slash = x.path[:-1] if x.path[-1] == '/' else x.path
-                y = luigi.contrib.hdfs.HdfsTarget(x_path_no_slash + '-luigi-tmp-%09d' % random.randrange(0, 1e10))
+                y = luigi.contrib.hdfs.HdfsTarget(x_path_no_slash + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10)))
                 tmp_files.append((y, x_path_no_slash))
                 logger.info('Using temp path: %s for path %s', y.path, x.path)
                 args.append(y.path)

--- a/luigi/contrib/hdfs/config.py
+++ b/luigi/contrib/hdfs/config.py
@@ -107,7 +107,7 @@ def tmppath(path=None, include_unix_username=True):
 
     Note that include_unix_username might work on windows too.
     """
-    addon = "luigitemp-%08d" % random.randrange(1e9)
+    addon = "luigitemp-{0:08d}".format(random.randrange(1e9))
     temp_dir = '/tmp'  # default tmp dir if none is specified in config
 
     # 1. Figure out to which temporary directory to place

--- a/luigi/contrib/hdfs/format.py
+++ b/luigi/contrib/hdfs/format.py
@@ -53,7 +53,7 @@ class HdfsAtomicWriteDirPipe(luigi.format.OutputPipeProcessWrapper):
     def __init__(self, path, data_extension=""):
         self.path = path
         self.tmppath = hdfs_config.tmppath(self.path)
-        self.datapath = self.tmppath + ("/data%s" % data_extension)
+        self.datapath = self.tmppath + ("/data{0!s}".format(data_extension))
         super(HdfsAtomicWriteDirPipe, self).__init__(load_hadoop_cmd() + ['fs', '-put', '-', self.datapath])
 
     def abort(self):
@@ -98,7 +98,7 @@ class PlainDirFormat(luigi.format.Format):
 
     def pipe_reader(self, path):
         # exclude underscore-prefixedfiles/folders (created by MapReduce)
-        return HdfsReadPipe("%s/[^_]*" % path)
+        return HdfsReadPipe("{0!s}/[^_]*".format(path))
 
     def pipe_writer(self, path):
         return HdfsAtomicWriteDirPipe(path)

--- a/luigi/contrib/hdfs/hadoopcli_clients.py
+++ b/luigi/contrib/hdfs/hadoopcli_clients.py
@@ -121,7 +121,7 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
             owner = ''
         if group is None:
             group = ''
-        ownership = "%s:%s" % (owner, group)
+        ownership = "{0!s}:{1!s}".format(owner, group)
         if recursive:
             cmd = load_hadoop_cmd() + ['fs', '-chown', '-R', ownership, path]
         else:
@@ -203,7 +203,7 @@ class HdfsClient(hdfs_abstract_client.HdfsFileSystem):
             if include_type:
                 extra_data += (line_type,)
             if include_time:
-                time_str = '%sT%s' % (data[-3], data[-2])
+                time_str = '{0!s}T{1!s}'.format(data[-3], data[-2])
                 modification_time = datetime.datetime.strptime(time_str,
                                                                '%Y-%m-%dT%H:%M')
                 extra_data += (modification_time,)

--- a/luigi/contrib/hdfs/snakebite_client.py
+++ b/luigi/contrib/hdfs/snakebite_client.py
@@ -179,7 +179,7 @@ class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         bite = self.get_bite()
         if owner:
             if group:
-                return all(bite.chown(self.list_path(path), "%s:%s" % (owner, group),
+                return all(bite.chown(self.list_path(path), "{0!s}:{1!s}".format(owner, group),
                                       recurse=recursive))
             return all(bite.chown(self.list_path(path), owner, recurse=recursive))
         return list(bite.chgrp(self.list_path(path), group, recurse=recursive))
@@ -243,7 +243,7 @@ class SnakebiteHdfsClient(hdfs_abstract_client.HdfsFileSystem):
         result = list(self.get_bite().mkdir(self.list_path(path),
                                             create_parent=parents, mode=mode))
         if raise_if_exists and "ile exists" in result[0].get('error', ''):
-            raise luigi.target.FileAlreadyExists("%s exists" % (path, ))
+            raise luigi.target.FileAlreadyExists("{0!s} exists".format(path ))
         return result
 
     def listdir(self, path, ignore_directories=False, ignore_files=False,

--- a/luigi/contrib/hdfs/target.py
+++ b/luigi/contrib/hdfs/target.py
@@ -108,7 +108,7 @@ class HdfsTarget(FileSystemTarget):
 
     def open(self, mode='r'):
         if mode not in ('r', 'w'):
-            raise ValueError("Unsupported open mode '%s'" % mode)
+            raise ValueError("Unsupported open mode '{0!s}'".format(mode))
 
         if mode == 'r':
             return self.format.pipe_reader(self.path)
@@ -128,7 +128,7 @@ class HdfsTarget(FileSystemTarget):
         if isinstance(path, HdfsTarget):
             path = path.path
         if raise_if_exists and self.fs.exists(path):
-            raise RuntimeError('Destination exists: %s' % path)
+            raise RuntimeError('Destination exists: {0!s}'.format(path))
         self.fs.rename(self.path, path)
 
     def move(self, path, raise_if_exists=False):
@@ -178,7 +178,7 @@ class HdfsTarget(FileSystemTarget):
             return False
 
     def _is_writable(self, path):
-        test_path = path + '.test_write_access-%09d' % random.randrange(1e10)
+        test_path = path + '.test_write_access-{0:09d}'.format(random.randrange(1e10))
         try:
             self.fs.touchz(test_path)
             self.fs.remove(test_path, recursive=False)

--- a/luigi/contrib/hive.py
+++ b/luigi/contrib/hive.py
@@ -141,8 +141,8 @@ class HiveCommandClient(HiveClient):
 
             return stdout and table.lower() in stdout
         else:
-            stdout = run_hive_cmd("""use %s; show partitions %s partition
-                                (%s)""" % (database, table, self.partition_spec(partition)))
+            stdout = run_hive_cmd("""use {0!s}; show partitions {1!s} partition
+                                ({2!s})""".format(database, table, self.partition_spec(partition)))
 
             if stdout:
                 return True
@@ -215,7 +215,7 @@ class MetastoreClient(HiveClient):
             return [(field_schema.name, field_schema.type) for field_schema in client.get_schema(database, table)]
 
     def partition_spec(self, partition):
-        return "/".join("%s=%s" % (k, v) for (k, v) in sorted(six.iteritems(partition), key=operator.itemgetter(0)))
+        return "/".join("{0!s}={1!s}".format(k, v) for (k, v) in sorted(six.iteritems(partition), key=operator.itemgetter(0)))
 
 
 class HiveThriftContext(object):

--- a/luigi/contrib/opener.py
+++ b/luigi/contrib/opener.py
@@ -92,7 +92,7 @@ class OpenerRegistry(object):
 
         """
         if name not in self.registry:
-            raise NoOpenerError("No opener for %s" % name)
+            raise NoOpenerError("No opener for {0!s}".format(name))
         index = self.registry[name]
         return self.openers[index]
 

--- a/luigi/contrib/pig.py
+++ b/luigi/contrib/pig.py
@@ -100,7 +100,7 @@ class PigJobTask(luigi.Task):
         opts = self.pig_options()
 
         def line(k, v):
-            return ('%s=%s%s' % (k, v, os.linesep)).encode('utf-8')
+            return ('{0!s}={1!s}{2!s}'.format(k, v, os.linesep)).encode('utf-8')
 
         with tempfile.NamedTemporaryFile() as param_file, tempfile.NamedTemporaryFile() as prop_file:
             if self.pig_parameters():
@@ -163,7 +163,7 @@ class PigJobTask(luigi.Task):
         else:
             logger.error("Error when running script:\n%s", self.pig_script_path())
             logger.error(err)
-            raise PigJobError("Pig script failed with return value: %s" % (proc.returncode,), err=err)
+            raise PigJobError("Pig script failed with return value: {0!s}".format(proc.returncode), err=err)
 
 
 class PigRunContext(object):
@@ -178,7 +178,7 @@ class PigRunContext(object):
     def kill_job(self, captured_signal=None, stack_frame=None):
         if self.job_id:
             logger.info('Job interrupted, killing job %s', self.job_id)
-            subprocess.call(['pig', '-e', '"kill %s"' % self.job_id])
+            subprocess.call(['pig', '-e', '"kill {0!s}"'.format(self.job_id)])
         if captured_signal is not None:
             # adding 128 gives the exit code corresponding to a signal
             sys.exit(128 + captured_signal)

--- a/luigi/contrib/rdbms.py
+++ b/luigi/contrib/rdbms.py
@@ -86,7 +86,7 @@ class CopyToTable(luigi.task.MixinNaiveBulkComplete, luigi.Task):
         """
         if len(self.columns[0]) == 1:
             # only names of columns specified, no types
-            raise NotImplementedError("create_table() not implemented for %r and columns types not specified" % self.table)
+            raise NotImplementedError("create_table() not implemented for {0!r} and columns types not specified".format(self.table))
         elif len(self.columns[0]) == 2:
             # if columns is specified as (name, type) tuples
             coldefs = ','.join(

--- a/luigi/contrib/redis_store.py
+++ b/luigi/contrib/redis_store.py
@@ -76,7 +76,7 @@ class RedisTarget(Target):
         """
         Generate a key for the indicator hash.
         """
-        return '%s:%s' % (self.marker_prefix, self.update_id)
+        return '{0!s}:{1!s}'.format(self.marker_prefix, self.update_id)
 
     def touch(self):
         """

--- a/luigi/contrib/redshift.py
+++ b/luigi/contrib/redshift.py
@@ -177,7 +177,7 @@ class S3CopyToTable(rdbms.CopyToTable):
         return []
 
     def truncate_table(self, connection):
-        query = "truncate %s" % self.table
+        query = "truncate {0!s}".format(self.table)
         cursor = connection.cursor()
         try:
             cursor.execute(query)
@@ -185,7 +185,7 @@ class S3CopyToTable(rdbms.CopyToTable):
             cursor.close()
 
     def prune(self, connection):
-        query = "delete from %s where %s >= %s" % (self.prune_table, self.prune_column, self.prune_date)
+        query = "delete from {0!s} where {1!s} >= {2!s}".format(self.prune_table, self.prune_column, self.prune_date)
         cursor = connection.cursor()
         try:
             cursor.execute(query)
@@ -256,10 +256,10 @@ class S3CopyToTable(rdbms.CopyToTable):
         """
         logger.info("Inserting file: %s", f)
         cursor.execute("""
-         COPY %s from '%s'
-         CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'
-         %s
-         ;""" % (self.table, f, self.aws_access_key_id,
+         COPY {0!s} from '{1!s}'
+         CREDENTIALS 'aws_access_key_id={2!s};aws_secret_access_key={3!s}'
+         {4!s}
+         ;""".format(self.table, f, self.aws_access_key_id,
                  self.aws_secret_access_key, self.copy_options))
 
     def output(self):
@@ -367,11 +367,11 @@ class S3CopyJSONToTable(S3CopyToTable):
         """
 
         cursor.execute("""
-         COPY %s from '%s'
-         CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'
-         JSON AS '%s' %s
-         %s
-         ;""" % (self.table, f, self.aws_access_key_id,
+         COPY {0!s} from '{1!s}'
+         CREDENTIALS 'aws_access_key_id={2!s};aws_secret_access_key={3!s}'
+         JSON AS '{4!s}' {5!s}
+         {6!s}
+         ;""".format(self.table, f, self.aws_access_key_id,
                  self.aws_secret_access_key, self.jsonpath,
                  self.copy_json_options, self.copy_options))
 
@@ -410,7 +410,7 @@ class RedshiftManifestTask(S3PathTask):
             client = s3.fs
             for file_name in client.list(s3.path):
                 entries.append({
-                    'url': '%s/%s' % (folder_path, file_name),
+                    'url': '{0!s}/{1!s}'.format(folder_path, file_name),
                     'mandatory': True
                 })
         manifest = {'entries': entries}

--- a/luigi/contrib/scalding.py
+++ b/luigi/contrib/scalding.py
@@ -204,7 +204,7 @@ class ScaldingJobRunner(luigi.contrib.hadoop.JobRunner):
         scalding_core = self.get_scalding_core()
         libjars = ','.join(filter(None, jars))
         arglist = luigi.contrib.hdfs.load_hadoop_cmd() + ['jar', scalding_core, '-libjars', libjars]
-        arglist += ['-D%s' % c for c in job.jobconfs()]
+        arglist += ['-D{0!s}'.format(c) for c in job.jobconfs()]
 
         job_class = job.job_class() or self.get_job_class(job.source())
         arglist += [job_class, '--hdfs']

--- a/luigi/contrib/sge.py
+++ b/luigi/contrib/sge.py
@@ -192,7 +192,7 @@ class SGEJobTask(luigi.Task):
 
         # Set up temp folder in shared directory (trim to max filename length)
         base_tmp_dir = self.shared_tmp_dir
-        random_id = '%016x' % random.getrandbits(64)
+        random_id = '{0:016x}'.format(random.getrandbits(64))
         folder_name = self.task_id + '-' + random_id
         self.tmp_dir = os.path.join(base_tmp_dir, folder_name)
         max_filename_length = os.fstatvfs(0).f_namemax
@@ -261,7 +261,7 @@ class SGEJobTask(luigi.Task):
 
         # Now delete the temporaries, if they're there.
         if self.tmp_dir and os.path.exists(self.tmp_dir):
-            logger.info('Removing temporary directory %s' % self.tmp_dir)
+            logger.info('Removing temporary directory {0!s}'.format(self.tmp_dir))
             shutil.rmtree(self.tmp_dir)
 
     def _track_job(self):
@@ -290,8 +290,8 @@ class SGEJobTask(luigi.Task):
                 break
             else:
                 logger.info('Job status is UNKNOWN!')
-                logger.info('Status is : %s' % sge_status)
-                raise Exception("job status isn't one of ['r', 'qw', 'E*', 't', 'u']: %s" % sge_status)
+                logger.info('Status is : {0!s}'.format(sge_status))
+                raise Exception("job status isn't one of ['r', 'qw', 'E*', 't', 'u']: {0!s}".format(sge_status))
 
 
 class LocalSGEJobTask(SGEJobTask):

--- a/luigi/contrib/sqla.py
+++ b/luigi/contrib/sqla.py
@@ -324,7 +324,7 @@ class CopyToTable(luigi.Task):
         needs_setup = (len(self.columns) == 0) or (False in [len(c) == 2 for c in self.columns]) if not self.reflect else False
         if needs_setup:
             # only names of columns specified, no types
-            raise NotImplementedError("create_table() not implemented for %r and columns types not specified" % self.table)
+            raise NotImplementedError("create_table() not implemented for {0!r} and columns types not specified".format(self.table))
         else:
             # if columns is specified as (name, type) tuples
             with engine.begin() as con:
@@ -365,7 +365,7 @@ class CopyToTable(luigi.Task):
                 yield line.strip("\n").split(self.column_separator)
 
     def run(self):
-        self._logger.info("Running task copy to table for update id %s for table %s" % (self.update_id(), self.table))
+        self._logger.info("Running task copy to table for update id {0!s} for table {1!s}".format(self.update_id(), self.table))
         output = self.output()
         engine = output.engine
         self.create_table(engine)
@@ -377,7 +377,7 @@ class CopyToTable(luigi.Task):
                 self.copy(conn, ins_rows, self.table_bound)
                 ins_rows = [dict(zip(("_" + c.key for c in self.table_bound.c), row))
                             for row in itertools.islice(rows, self.chunk_size)]
-                self._logger.info("Finished inserting %d rows into SQLAlchemy target" % len(ins_rows))
+                self._logger.info("Finished inserting {0:d} rows into SQLAlchemy target".format(len(ins_rows)))
         output.touch()
         self._logger.info("Finished inserting rows into SQLAlchemy target")
 

--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -58,7 +58,7 @@ class RemoteCalledProcessError(subprocess.CalledProcessError):
         self.host = host
 
     def __str__(self):
-        return "Command '%s' on host %s returned non-zero exit status %d" % (
+        return "Command '{0!s}' on host {1!s} returned non-zero exit status {2:d}".format(
             self.cmd, self.host, self.returncode)
 
 
@@ -75,7 +75,7 @@ class RemoteContext(object):
         self.tty = kwargs.get('tty', False)
 
     def __repr__(self):
-        return '%s(%r, %r, %r, %r, %r)' % (
+        return '{0!s}({1!r}, {2!r}, {3!r}, {4!r}, {5!r})'.format(
             type(self).__name__, self.host, self.username, self.key_file, self.connect_timeout, self.port)
 
     def __eq__(self, other):
@@ -100,7 +100,7 @@ class RemoteContext(object):
             connection_cmd.extend(["-p", self.port])
 
         if self.connect_timeout is not None:
-            connection_cmd += ['-o', 'ConnectTimeout=%d' % self.connect_timeout]
+            connection_cmd += ['-o', 'ConnectTimeout={0:d}'.format(self.connect_timeout)]
 
         if self.no_host_key_check:
             connection_cmd += ['-o', 'UserKnownHostsFile=/dev/null',
@@ -152,7 +152,7 @@ class RemoteContext(object):
         assert ready == b"ready", "Didn't get ready from remote echo"
         yield  # user code executed here
         proc.communicate()
-        assert proc.returncode == 0, "Tunnel process did an unclean exit (returncode %s)" % (proc.returncode,)
+        assert proc.returncode == 0, "Tunnel process did an unclean exit (returncode {0!s})".format(proc.returncode)
 
 
 class RemoteFileSystem(luigi.target.FileSystem):
@@ -254,8 +254,8 @@ class RemoteFileSystem(luigi.target.FileSystem):
         if folder and not self.exists(folder):
             self.remote_context.check_output(['mkdir', '-p', folder])
 
-        tmp_path = path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
-        self._scp(local_path, "%s:%s" % (self.remote_context._host_ref(), tmp_path))
+        tmp_path = path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
+        self._scp(local_path, "{0!s}:{1!s}".format(self.remote_context._host_ref(), tmp_path))
         self.remote_context.check_output(['mv', tmp_path, path])
 
     def get(self, path, local_path):
@@ -268,8 +268,8 @@ class RemoteFileSystem(luigi.target.FileSystem):
             except OSError:
                 pass
 
-        tmp_local_path = local_path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
-        self._scp("%s:%s" % (self.remote_context._host_ref(), path), tmp_local_path)
+        tmp_local_path = local_path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
+        self._scp("{0!s}:{1!s}".format(self.remote_context._host_ref(), path), tmp_local_path)
         os.rename(tmp_local_path, local_path)
 
 
@@ -285,7 +285,7 @@ class AtomicRemoteFileWriter(luigi.format.OutputPipeProcessWrapper):
         if folder:
             self.fs.mkdir(folder)
 
-        self.__tmp_path = self.path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
+        self.__tmp_path = self.path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
         super(AtomicRemoteFileWriter, self).__init__(
             self.fs.remote_context._prepare_cmd(['cat', '>', self.__tmp_path]))
 

--- a/luigi/contrib/webhdfs.py
+++ b/luigi/contrib/webhdfs.py
@@ -50,7 +50,7 @@ class WebHdfsTarget(FileSystemTarget):
 
     def open(self, mode='r'):
         if mode not in ('r', 'w'):
-            raise ValueError("Unsupported open mode '%s'" % mode)
+            raise ValueError("Unsupported open mode '{0!s}'".format(mode))
 
         if mode == 'r':
             return self.format.pipe_reader(

--- a/luigi/date_interval.py
+++ b/luigi/date_interval.py
@@ -201,7 +201,7 @@ class Week(DateInterval):
         super(Week, self).__init__(date_a, date_b)
 
     def to_string(self):
-        return '%d-W%02d' % self.date_a.isocalendar()[:2]
+        return '{0:d}-W{1:02d}'.format(*self.date_a.isocalendar()[:2])
 
     @classmethod
     def from_date(cls, d):

--- a/luigi/db_task_history.py
+++ b/luigi/db_task_history.py
@@ -199,7 +199,7 @@ class TaskParameter(Base):
     value = sqlalchemy.Column(sqlalchemy.String(256))
 
     def __repr__(self):
-        return "TaskParameter(task_id=%d, name=%s, value=%s)" % (self.task_id, self.name, self.value)
+        return "TaskParameter(task_id={0:d}, name={1!s}, value={2!s})".format(self.task_id, self.name, self.value)
 
 
 class TaskEvent(Base):
@@ -213,7 +213,7 @@ class TaskEvent(Base):
     ts = sqlalchemy.Column(sqlalchemy.TIMESTAMP, index=True, nullable=False)
 
     def __repr__(self):
-        return "TaskEvent(task_id=%s, event_name=%s, ts=%s" % (self.task_id, self.event_name, self.ts)
+        return "TaskEvent(task_id={0!s}, event_name={1!s}, ts={2!s}".format(self.task_id, self.event_name, self.ts)
 
 
 class TaskRecord(Base):
@@ -237,7 +237,7 @@ class TaskRecord(Base):
         backref='task')
 
     def __repr__(self):
-        return "TaskRecord(name=%s, host=%s)" % (self.name, self.host)
+        return "TaskRecord(name={0!s}, host={1!s})".format(self.name, self.host)
 
 
 def _upgrade_schema(engine):

--- a/luigi/file.py
+++ b/luigi/file.py
@@ -39,7 +39,7 @@ class atomic_file(AtomicLocalFile):
         os.rename(self.tmp_path, self.path)
 
     def generate_tmp_path(self, path):
-        return path + '-luigi-tmp-%09d' % random.randrange(0, 1e10)
+        return path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10))
 
 
 class LocalFileSystem(FileSystem):
@@ -85,7 +85,7 @@ class LocalFileSystem(FileSystem):
 
     def move(self, old_path, new_path, raise_if_exists=False):
         if raise_if_exists and os.path.exists(new_path):
-            raise RuntimeError('Destination exists: %s' % new_path)
+            raise RuntimeError('Destination exists: {0!s}'.format(new_path))
         d = os.path.dirname(new_path)
         if d and not os.path.exists(d):
             self.fs.mkdir(d)
@@ -102,7 +102,7 @@ class LocalTarget(FileSystemTarget):
         if not path:
             if not is_tmp:
                 raise Exception('path or is_tmp must be set')
-            path = os.path.join(tempfile.gettempdir(), 'luigi-tmp-%09d' % random.randint(0, 999999999))
+            path = os.path.join(tempfile.gettempdir(), 'luigi-tmp-{0:09d}'.format(random.randint(0, 999999999)))
         super(LocalTarget, self).__init__(path)
         self.format = format
         self.is_tmp = is_tmp
@@ -130,7 +130,7 @@ class LocalTarget(FileSystemTarget):
             return self.format.pipe_reader(fileobj)
 
         else:
-            raise Exception('mode must be r/w (got:%s)' % mode)
+            raise Exception('mode must be r/w (got:{0!s})'.format(mode))
 
     def move(self, new_path, raise_if_exists=False):
         self.fs.move(self.path, new_path, raise_if_exists=raise_if_exists)
@@ -143,8 +143,8 @@ class LocalTarget(FileSystemTarget):
 
     def copy(self, new_path, raise_if_exists=False):
         if raise_if_exists and os.path.exists(new_path):
-            raise RuntimeError('Destination exists: %s' % new_path)
-        tmp = LocalTarget(new_path + '-luigi-tmp-%09d' % random.randrange(0, 1e10), is_tmp=True)
+            raise RuntimeError('Destination exists: {0!s}'.format(new_path))
+        tmp = LocalTarget(new_path + '-luigi-tmp-{0:09d}'.format(random.randrange(0, 1e10)), is_tmp=True)
         tmp.makedirs()
         shutil.copy(self.path, tmp.fn)
         tmp.move(new_path)

--- a/luigi/format.py
+++ b/luigi/format.py
@@ -119,7 +119,7 @@ class InputPipeProcessWrapper(object):
         if self._process.returncode not in (0, 141, 128 - 141):
             # 141 == 128 + 13 == 128 + SIGPIPE - normally processes exit with 128 + {reiceived SIG}
             # 128 - 141 == -13 == -SIGPIPE, sometimes python receives -13 for some subprocesses
-            raise RuntimeError('Error reading from pipe. Subcommand exited with non-zero exit status %s.' % self._process.returncode)
+            raise RuntimeError('Error reading from pipe. Subcommand exited with non-zero exit status {0!s}.'.format(self._process.returncode))
 
     def close(self):
         self._finish()
@@ -223,7 +223,7 @@ class OutputPipeProcessWrapper(object):
             if self._output_pipe is not None:
                 self._output_pipe.close()
         else:
-            raise RuntimeError('Error when executing command %s' % self._command)
+            raise RuntimeError('Error when executing command {0!s}'.format(self._command))
 
     def abort(self):
         self._finish()

--- a/luigi/lock.py
+++ b/luigi/lock.py
@@ -35,7 +35,7 @@ def getpcmd(pid):
     """
     if os.name == "nt":
         # Use wmic command instead of ps on Windows.
-        cmd = 'wmic path win32_process where ProcessID=%s get Commandline' % (pid, )
+        cmd = 'wmic path win32_process where ProcessID={0!s} get Commandline'.format(pid )
         with os.popen(cmd, 'r') as p:
             lines = [line for line in p.readlines() if line.strip("\r\n ") != ""]
             if lines:
@@ -109,7 +109,7 @@ def acquire_for(pid_dir, num_available=1, kill_signal=None):
     # Write pids
     pids.add(str(my_pid))
     with open(pid_file, 'w') as f:
-        f.writelines('%s\n' % (pid, ) for pid in filter(pid_cmds.__getitem__, pids))
+        f.writelines('{0!s}\n'.format(pid ) for pid in filter(pid_cmds.__getitem__, pids))
 
     # Make the file writable by all
     if os.name == 'nt':

--- a/luigi/mock.py
+++ b/luigi/mock.py
@@ -103,7 +103,7 @@ class MockTarget(target.FileSystemTarget):
 
     def rename(self, path, raise_if_exists=False):
         if raise_if_exists and path in self.fs.get_all_data():
-            raise RuntimeError('Destination exists: %s' % path)
+            raise RuntimeError('Destination exists: {0!s}'.format(path))
         contents = self.fs.get_all_data().pop(self._fn)
         self.fs.get_all_data()[path] = contents
 

--- a/luigi/mrrunner.py
+++ b/luigi/mrrunner.py
@@ -54,7 +54,7 @@ class Runner(object):
         elif kind == "reduce":
             self.job.run_reducer(stdin, stdout)
         else:
-            raise Exception('weird command: %s' % kind)
+            raise Exception('weird command: {0!s}'.format(kind))
 
     def extract_packages_archive(self):
         if not os.path.exists("packages.tar"):
@@ -70,7 +70,7 @@ class Runner(object):
 
 def print_exception(exc):
     tb = traceback.format_exc()
-    print('luigi-exc-hex=%s' % tb.encode('hex'), file=sys.stderr)
+    print('luigi-exc-hex={0!s}'.format(tb.encode('hex')), file=sys.stderr)
 
 
 def main(args=None, stdin=sys.stdin, stdout=sys.stdout, print_exception=print_exception):

--- a/luigi/notifications.py
+++ b/luigi/notifications.py
@@ -41,7 +41,7 @@ import luigi.parameter
 logger = logging.getLogger("luigi-interface")
 
 
-DEFAULT_CLIENT_EMAIL = 'luigi-client@%s' % socket.gethostname()
+DEFAULT_CLIENT_EMAIL = 'luigi-client@{0!s}'.format(socket.gethostname())
 DEBUG = False
 
 
@@ -114,7 +114,7 @@ def wrap_traceback(traceback):
             formatter = HtmlFormatter(noclasses=True)
             wrapped = highlight(traceback, PythonTracebackLexer(), formatter)
         else:
-            wrapped = '<pre>%s</pre>' % traceback
+            wrapped = '<pre>{0!s}</pre>'.format(traceback)
     else:
         wrapped = traceback
 
@@ -311,7 +311,7 @@ def _prefix(subject):
     config = configuration.get_config()
     email_prefix = config.get('core', 'email-prefix', None)
     if email_prefix is not None:
-        subject = "%s %s" % (email_prefix, subject)
+        subject = "{0!s} {1!s}".format(email_prefix, subject)
     return subject
 
 

--- a/luigi/parameter.py
+++ b/luigi/parameter.py
@@ -608,19 +608,19 @@ class TimeDeltaParameter(Parameter):
 
     def _parseIso8601(self, input):
         def field(key):
-            return r"(?P<%s>\d+)%s" % (key, key[0].upper())
+            return r"(?P<{0!s}>\d+){1!s}".format(key, key[0].upper())
 
         def optional_field(key):
-            return "(%s)?" % field(key)
+            return "({0!s})?".format(field(key))
         # A little loose: ISO 8601 does not allow weeks in combination with other fields, but this regex does (as does python timedelta)
-        regex = "P(%s|%s(T%s)?)" % (field("weeks"), optional_field("days"), "".join([optional_field(key) for key in ["hours", "minutes", "seconds"]]))
+        regex = "P({0!s}|{1!s}(T{2!s})?)".format(field("weeks"), optional_field("days"), "".join([optional_field(key) for key in ["hours", "minutes", "seconds"]]))
         return self._apply_regex(regex, input)
 
     def _parseSimple(self, input):
         keys = ["weeks", "days", "hours", "minutes", "seconds"]
         # Give the digits a regex group name from the keys, then look for text with the first letter of the key,
         # optionally followed by the rest of the word, with final char (the "s") optional
-        regex = "".join([r"((?P<%s>\d+) ?%s(%s)?(%s)? ?)?" % (k, k[0], k[1:-1], k[-1]) for k in keys])
+        regex = "".join([r"((?P<{0!s}>\d+) ?{1!s}({2!s})?({3!s})? ?)?".format(k, k[0], k[1:-1], k[-1]) for k in keys])
         return self._apply_regex(regex, input)
 
     def parse(self, input):
@@ -635,7 +635,7 @@ class TimeDeltaParameter(Parameter):
         if result:
             return result
         else:
-            raise ParameterException("Invalid time delta - could not parse %s" % input)
+            raise ParameterException("Invalid time delta - could not parse {0!s}".format(input))
 
 
 class TaskParameter(Parameter):
@@ -729,7 +729,7 @@ class FrozenOrderedDict(Mapping):
         return len(self.__dict)
 
     def __repr__(self):
-        return '<FrozenOrderedDict %s>' % repr(self.__dict)
+        return '<FrozenOrderedDict {0!s}>'.format(repr(self.__dict))
 
     def __hash__(self):
         if self.__hash is None:

--- a/luigi/postgres.py
+++ b/luigi/postgres.py
@@ -285,7 +285,7 @@ class CopyToTable(rdbms.CopyToTable):
         elif len(self.columns[0]) == 2:
             column_names = [c[0] for c in self.columns]
         else:
-            raise Exception('columns must consist of column strings or (column string, type string) tuples (was %r ...)' % (self.columns[0],))
+            raise Exception('columns must consist of column strings or (column string, type string) tuples (was {0!r} ...)'.format(self.columns[0]))
         cursor.copy_from(file, self.table, null=r'\\N', sep=self.column_separator, columns=column_names)
 
     def run(self):

--- a/luigi/rpc.py
+++ b/luigi/rpc.py
@@ -133,8 +133,7 @@ class RemoteScheduler(Scheduler):
                 continue
         else:
             raise RPCError(
-                "Errors (%d attempts) when connecting to remote scheduler %r" %
-                (attempts, self._url),
+                "Errors ({0:d} attempts) when connecting to remote scheduler {1!r}".format(attempts, self._url),
                 last_exception
             )
         return response
@@ -147,7 +146,7 @@ class RemoteScheduler(Scheduler):
             response = json.loads(page)["response"]
             if allow_null or response is not None:
                 return response
-        raise RPCError("Received null response from remote scheduler %r" % self._url)
+        raise RPCError("Received null response from remote scheduler {0!r}".format(self._url))
 
     def ping(self, worker):
         # just one attempt, keep-alive thread will keep trying anyway

--- a/luigi/s3.py
+++ b/luigi/s3.py
@@ -150,7 +150,7 @@ class S3Client(FileSystem):
 
         # root
         if self._is_root(key):
-            raise InvalidDeleteException('Cannot delete root of bucket at path %s' % path)
+            raise InvalidDeleteException('Cannot delete root of bucket at path {0!s}'.format(path))
 
         # grab and validate the bucket
         s3_bucket = self.s3.get_bucket(bucket, validate=True)
@@ -163,7 +163,7 @@ class S3Client(FileSystem):
             return True
 
         if self.isdir(path) and not recursive:
-            raise InvalidDeleteException('Path %s is a directory. Must use recursive delete' % path)
+            raise InvalidDeleteException('Path {0!s} is a directory. Must use recursive delete'.format(path))
 
         delete_key_list = [
             k for k in s3_bucket.list(self._add_path_delimiter(key))]
@@ -364,8 +364,7 @@ class S3Client(FileSystem):
 
             end = datetime.datetime.now()
             duration = end - start
-            logger.info('%s : Complete : %s total keys copied in %s' %
-                        (datetime.datetime.now(), total_keys, duration))
+            logger.info('{0!s} : Complete : {1!s} total keys copied in {2!s}'.format(datetime.datetime.now(), total_keys, duration))
 
         # If the file isn't a directory just perform a simple copy
         else:
@@ -675,12 +674,12 @@ class S3Target(FileSystemTarget):
         """
         """
         if mode not in ('r', 'w'):
-            raise ValueError("Unsupported open mode '%s'" % mode)
+            raise ValueError("Unsupported open mode '{0!s}'".format(mode))
 
         if mode == 'r':
             s3_key = self.fs.get_key(self.path)
             if not s3_key:
-                raise FileNotFoundException("Could not find file at %s" % self.path)
+                raise FileNotFoundException("Could not find file at {0!s}".format(self.path))
 
             fileobj = ReadableS3File(s3_key)
             return self.format.pipe_reader(fileobj)

--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -193,7 +193,7 @@ class Task(object):
         self.runnable = False
 
     def __repr__(self):
-        return "Task(%r)" % vars(self)
+        return "Task({0!r})".format(vars(self))
 
     def add_failure(self):
         self.failures.add_failure()

--- a/luigi/six.py
+++ b/luigi/six.py
@@ -484,7 +484,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/luigi/target.py
+++ b/luigi/target.py
@@ -270,7 +270,7 @@ class AtomicLocalFile(io.BufferedWriter):
         self.move_to_final_destination()
 
     def generate_tmp_path(self, path):
-        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-%09d' % random.randrange(0, 1e10))
+        return os.path.join(tempfile.gettempdir(), 'luigi-s3-tmp-{0:09d}'.format(random.randrange(0, 1e10)))
 
     def move_to_final_destination(self):
         raise NotImplementedError()

--- a/luigi/task.py
+++ b/luigi/task.py
@@ -240,29 +240,29 @@ class Task(object):
 
         # In case any exceptions are thrown, create a helpful description of how the Task was invoked
         # TODO: should we detect non-reprable arguments? These will lead to mysterious errors
-        exc_desc = '%s[args=%s, kwargs=%s]' % (task_name, args, kwargs)
+        exc_desc = '{0!s}[args={1!s}, kwargs={2!s}]'.format(task_name, args, kwargs)
 
         # Fill in the positional arguments
         positional_params = [(n, p) for n, p in params if p.positional]
         for i, arg in enumerate(args):
             if i >= len(positional_params):
-                raise parameter.UnknownParameterException('%s: takes at most %d parameters (%d given)' % (exc_desc, len(positional_params), len(args)))
+                raise parameter.UnknownParameterException('{0!s}: takes at most {1:d} parameters ({2:d} given)'.format(exc_desc, len(positional_params), len(args)))
             param_name, param_obj = positional_params[i]
             result[param_name] = param_obj.normalize(arg)
 
         # Then the keyword arguments
         for param_name, arg in six.iteritems(kwargs):
             if param_name in result:
-                raise parameter.DuplicateParameterException('%s: parameter %s was already set as a positional parameter' % (exc_desc, param_name))
+                raise parameter.DuplicateParameterException('{0!s}: parameter {1!s} was already set as a positional parameter'.format(exc_desc, param_name))
             if param_name not in params_dict:
-                raise parameter.UnknownParameterException('%s: unknown parameter %s' % (exc_desc, param_name))
+                raise parameter.UnknownParameterException('{0!s}: unknown parameter {1!s}'.format(exc_desc, param_name))
             result[param_name] = params_dict[param_name].normalize(arg)
 
         # Then use the defaults for anything not filled in
         for param_name, param_obj in params:
             if param_name not in result:
                 if not param_obj.has_task_value(task_name, param_name):
-                    raise parameter.MissingParameterException("%s: requires the '%s' parameter to be set" % (exc_desc, param_name))
+                    raise parameter.MissingParameterException("{0!s}: requires the '{1!s}' parameter to be set".format(exc_desc, param_name))
                 result[param_name] = param_obj.task_value(task_name, param_name)
 
         def list_to_tuple(x):
@@ -365,7 +365,7 @@ class Task(object):
         param_objs = dict(params)
         for param_name, param_value in param_values:
             if param_objs[param_name].significant:
-                repr_parts.append('%s=%s' % (param_name, param_objs[param_name].serialize(param_value)))
+                repr_parts.append('{0!s}={1!s}'.format(param_name, param_objs[param_name].serialize(param_value)))
 
         task_str = '{}({})'.format(self.task_family, ', '.join(repr_parts))
 
@@ -384,7 +384,7 @@ class Task(object):
         outputs = flatten(self.output())
         if len(outputs) == 0:
             warnings.warn(
-                "Task %r without outputs has no custom complete() method" % self,
+                "Task {0!r} without outputs has no custom complete() method".format(self),
                 stacklevel=2
             )
             return False
@@ -494,7 +494,7 @@ class Task(object):
         """
 
         traceback_string = traceback.format_exc()
-        return "Runtime error:\n%s" % traceback_string
+        return "Runtime error:\n{0!s}".format(traceback_string)
 
     def on_success(self):
         """
@@ -587,7 +587,7 @@ def getpaths(struct):
         try:
             s = list(struct)
         except TypeError:
-            raise Exception('Cannot map %s to Task/dict/list' % str(struct))
+            raise Exception('Cannot map {0!s} to Task/dict/list'.format(str(struct)))
 
         return [getpaths(r) for r in s]
 

--- a/luigi/task_register.py
+++ b/luigi/task_register.py
@@ -128,7 +128,7 @@ class Register(abc.ABCMeta):
         if cls.task_namespace is None:
             return cls.__name__
         else:
-            return "%s.%s" % (cls.task_namespace, cls.__name__)
+            return "{0!s}.{1!s}".format(cls.task_namespace, cls.__name__)
 
     @classmethod
     def _get_reg(cls):
@@ -184,7 +184,7 @@ class Register(abc.ABCMeta):
             raise TaskClassNotFoundException(cls._missing_task_msg(name))
 
         if task_cls == cls.AMBIGUOUS_CLASS:
-            raise TaskClassAmbigiousException('Task %r is ambiguous' % name)
+            raise TaskClassAmbigiousException('Task {0!r} is ambiguous'.format(name))
         return task_cls
 
     @classmethod
@@ -223,9 +223,9 @@ class Register(abc.ABCMeta):
         ordered_tasks = sorted(weighted_tasks, key=lambda pair: pair[0])
         candidates = [task for (dist, task) in ordered_tasks if dist <= 5 and dist < len(task)]
         if candidates:
-            return "No task %s. Did you mean:\n%s" % (task_name, '\n'.join(candidates))
+            return "No task {0!s}. Did you mean:\n{1!s}".format(task_name, '\n'.join(candidates))
         else:
-            return "No task %s. Candidates are: %s" % (task_name, cls.tasks_str())
+            return "No task {0!s}. Candidates are: {1!s}".format(task_name, cls.tasks_str())
 
 
 def load_task(module, task_name, params_str):

--- a/luigi/tools/range.py
+++ b/luigi/tools/range.py
@@ -171,7 +171,7 @@ class RangeBase(luigi.WrapperTask):
     def _format_range(self, datetimes):
         param_first = self._format_datetime(datetimes[0])
         param_last = self._format_datetime(datetimes[-1])
-        return '[%s, %s]' % (param_first, param_last)
+        return '[{0!s}, {1!s}]'.format(param_first, param_last)
 
     def _instantiate_task_cls(self, param):
         if self.param_name is None:
@@ -372,9 +372,9 @@ def _constrain_glob(glob, paths, limit=5):
         """
         chars = sorted(chars)
         if len(chars) > 1 and ord(chars[-1]) - ord(chars[0]) == len(chars) - 1:
-            return '[%s-%s]' % (chars[0], chars[-1])
+            return '[{0!s}-{1!s}]'.format(chars[0], chars[-1])
         else:
-            return '[%s]' % ''.join(chars)
+            return '[{0!s}]'.format(''.join(chars))
 
     current = {glob: paths}
     while True:
@@ -422,7 +422,7 @@ def _get_per_location_glob(tasks, outputs, regexes):
 
     for m, p, t in zip(matches, paths, tasks):
         if m is None:
-            raise NotImplementedError("Couldn't deduce datehour representation in output path %r of task %s" % (p, t))
+            raise NotImplementedError("Couldn't deduce datehour representation in output path {0!r} of task {1!s}".format(p, t))
 
     n_groups = len(matches[0].groups())
     # the most common position of every group is likely
@@ -455,12 +455,12 @@ def _get_filesystems_and_globs(datetime_to_task, datetime_to_re):
 
     for o, t in zip(sample_outputs, sample_tasks):
         if len(o) != len(sample_outputs[0]):
-            raise NotImplementedError("Outputs must be consistent over time, sorry; was %r for %r and %r for %r" % (o, t, sample_outputs[0], sample_tasks[0]))
+            raise NotImplementedError("Outputs must be consistent over time, sorry; was {0!r} for {1!r} and {2!r} for {3!r}".format(o, t, sample_outputs[0], sample_tasks[0]))
             # TODO fall back on requiring last couple of days? to avoid astonishing blocking when changes like that are deployed
             # erm, actually it's not hard to test entire hours_back..hours_forward and split into consistent subranges FIXME?
         for target in o:
             if not isinstance(target, FileSystemTarget):
-                raise NotImplementedError("Output targets must be instances of FileSystemTarget; was %r for %r" % (target, t))
+                raise NotImplementedError("Output targets must be instances of FileSystemTarget; was {0!r} for {1!r}".format(target, t))
 
     for o in zip(*sample_outputs):  # transposed, so here we're iterating over logical outputs, not datetimes
         glob = _get_per_location_glob(sample_tasks, o, regexes)

--- a/luigi/util.py
+++ b/luigi/util.py
@@ -380,7 +380,7 @@ def delegates(task_that_delegates):
         # This method can (optionally) define a couple of delegate tasks that
         # will be accessible as interfaces, meaning that the task can access
         # those tasks and run methods defined on them, etc
-        raise AttributeError('%s needs to implement the method "subtasks"' % task_that_delegates)
+        raise AttributeError('{0!s} needs to implement the method "subtasks"'.format(task_that_delegates))
 
     @task_wraps(task_that_delegates)
     class Wrapped(task_that_delegates):

--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -170,7 +170,7 @@ class TaskProcess(multiprocessing.Process):
                 missing = [dep.task_id for dep in self.task.deps() if not dep.complete()]
                 if missing:
                     deps = 'dependency' if len(missing) == 1 else 'dependencies'
-                    raise RuntimeError('Unfulfilled %s at run time: %s' % (deps, ', '.join(missing)))
+                    raise RuntimeError('Unfulfilled {0!s} at run time: {1!s}'.format(deps, ', '.join(missing)))
             self.task.trigger_event(Event.START, self.task)
             t0 = time.time()
             status = None
@@ -352,7 +352,7 @@ class KeepAliveThread(threading.Thread):
         while True:
             self._should_stop.wait(self._ping_interval)
             if self._should_stop.is_set():
-                logger.info("Worker %s was stopped. Shutting down Keep-Alive thread" % self._worker_id)
+                logger.info("Worker {0!s} was stopped. Shutting down Keep-Alive thread".format(self._worker_id))
                 break
             with fork_lock:
                 try:
@@ -379,7 +379,7 @@ class Worker(object):
         self._worker_info = self._generate_worker_info()
 
         if not worker_id:
-            worker_id = 'Worker(%s)' % ', '.join(['%s=%s' % (k, v) for k, v in self._worker_info])
+            worker_id = 'Worker({0!s})'.format(', '.join(['{0!s}={1!s}'.format(k, v) for k, v in self._worker_info]))
 
         self._config = worker(**kwargs)
 
@@ -460,7 +460,7 @@ class Worker(object):
     def _generate_worker_info(self):
         # Generate as much info as possible about the worker
         # Some of these calls might not be available on all OS's
-        args = [('salt', '%09d' % random.randrange(0, 999999999)),
+        args = [('salt', '{0:09d}'.format(random.randrange(0, 999999999))),
                 ('workers', self.worker_processes)]
         try:
             args += [('host', socket.gethostname())]
@@ -484,11 +484,11 @@ class Worker(object):
 
     def _validate_task(self, task):
         if not isinstance(task, Task):
-            raise TaskException('Can not schedule non-task %s' % task)
+            raise TaskException('Can not schedule non-task {0!s}'.format(task))
 
         if not task.initialized():
             # we can't get the repr of it since it's not initialized...
-            raise TaskException('Task of class %s not initialized. Did you override __init__ and forget to call super(...).__init__?' % task.__class__.__name__)
+            raise TaskException('Task of class {0!s} not initialized. Did you override __init__ and forget to call super(...).__init__?'.format(task.__class__.__name__))
 
     def _log_complete_error(self, task, tb):
         log_msg = "Will not schedule {task} or any dependencies due to error in complete() method:\n{tb}".format(task=task, tb=tb)
@@ -659,7 +659,7 @@ class Worker(object):
         if is_complete not in (True, False):
             if isinstance(is_complete, TracebackWrapper):
                 raise AsyncCompletionException(is_complete.trace)
-            raise Exception("Return value of Task.complete() must be boolean (was %r)" % is_complete)
+            raise Exception("Return value of Task.complete() must be boolean (was {0!r})".format(is_complete))
 
     def _add_worker(self):
         self._worker_info.append(('first_task', self._first_task))
@@ -706,9 +706,9 @@ class Worker(object):
                               task_name=r['task_family'],
                               params_str=r['task_params'])
             except TaskClassException as ex:
-                msg = 'Cannot find task for %s' % task_id
+                msg = 'Cannot find task for {0!s}'.format(task_id)
                 logger.exception(msg)
-                subject = 'Luigi: %s' % msg
+                subject = 'Luigi: {0!s}'.format(msg)
                 error_message = notifications.wrap_traceback(ex)
                 notifications.send_error_email(subject, error_message)
                 self._add_task(worker=self._id, task_id=task_id, status=FAILED, runnable=False,
@@ -758,10 +758,10 @@ class Worker(object):
         """
         for task_id, p in six.iteritems(self._running_tasks):
             if not p.is_alive() and p.exitcode:
-                error_msg = 'Task %s died unexpectedly with exit code %s' % (task_id, p.exitcode)
+                error_msg = 'Task {0!s} died unexpectedly with exit code {1!s}'.format(task_id, p.exitcode)
             elif p.timeout_time is not None and time.time() > float(p.timeout_time) and p.is_alive():
                 p.terminate()
-                error_msg = 'Task %s timed out and was terminated.' % task_id
+                error_msg = 'Task {0!s} timed out and was terminated.'.format(task_id)
             else:
                 continue
 

--- a/test/_mysqldb_test.py
+++ b/test/_mysqldb_test.py
@@ -34,7 +34,7 @@ def _create_test_database():
                                   host=host,
                                   port=port,
                                   autocommit=True)
-    con.cursor().execute('CREATE DATABASE IF NOT EXISTS %s' % database)
+    con.cursor().execute('CREATE DATABASE IF NOT EXISTS {0!s}'.format(database))
 
 
 _create_test_database()
@@ -54,4 +54,4 @@ class MySqlTargetTest(unittest.TestCase):
 
 def drop():
     con = target.connect(autocommit=True)
-    con.cursor().execute('DROP TABLE IF EXISTS %s' % table_updates)
+    con.cursor().execute('DROP TABLE IF EXISTS {0!s}'.format(table_updates))

--- a/test/_test_ftp.py
+++ b/test/_test_ftp.py
@@ -169,7 +169,7 @@ class TestRemoteTarget(unittest.TestCase):
         # manualy upload to ftp
         ftp = ftplib.FTP(HOST, USER, PWD)
         ftp.mkd("test")
-        ftp.storbinary('STOR %s' % remote_file, open(tmp_filepath, 'rb'))
+        ftp.storbinary('STOR {0!s}'.format(remote_file), open(tmp_filepath, 'rb'))
         ftp.close()
 
         # execute command

--- a/test/central_planner_test.py
+++ b/test/central_planner_test.py
@@ -954,7 +954,7 @@ class CentralPlannerTest(unittest.TestCase):
     def test_search_results_beyond_limit(self):
         sch = CentralPlannerScheduler(max_shown_tasks=3)
         for i in range(4):
-            sch.add_task(worker=WORKER, family='Test', params={'p': str(i)}, task_id='Test_%i' % i)
+            sch.add_task(worker=WORKER, family='Test', params={'p': str(i)}, task_id='Test_{0:d}'.format(i))
         self.assertEqual({'num_tasks': 4}, sch.task_list('PENDING', '', search='Test'))
         self.assertEqual(['Test_0'], list(sch.task_list('PENDING', '', search='0').keys()))
 

--- a/test/cmdline_test.py
+++ b/test/cmdline_test.py
@@ -36,7 +36,7 @@ class SomeTask(luigi.Task):
     n = luigi.IntParameter()
 
     def output(self):
-        return MockTarget('/tmp/test_%d' % self.n)
+        return MockTarget('/tmp/test_{0:d}'.format(self.n))
 
     def run(self):
         f = self.output().open('w')

--- a/test/contrib/hadoop_test.py
+++ b/test/contrib/hadoop_test.py
@@ -425,7 +425,7 @@ class JobRunnerTest(unittest.TestCase):
         yarn_lines = [
             "INFO mapreduce.JobSubmitter: Submitting tokens for job: job_1234_5678\n",
             "INFO impl.YarnClientImpl: Submitted application application_1234_5678\n",
-            "INFO mapreduce.Job: The url to track the job: %s\n" % url,
+            "INFO mapreduce.Job: The url to track the job: {0!s}\n".format(url),
             "INFO mapreduce.Job: Running job: job_1234_5678\n",
             "INFO mapreduce.Job: Job job_1234_5678 running in uber mode : false\n",
             "INFO mapreduce.Job: Job job_1234_5678 completed successfully\n",
@@ -436,7 +436,7 @@ class JobRunnerTest(unittest.TestCase):
     def test_tracking_url_old_version(self):
         url = 'http://tracker.com/1234_5678'
         err_lines = [
-            'INFO tracking url: %s\n' % url,
+            'INFO tracking url: {0!s}\n'.format(url),
         ]
         self._run_and_track(err_lines, 0)
         self.assertEqual([url], self.tracking_urls)
@@ -449,13 +449,13 @@ class JobRunnerTest(unittest.TestCase):
         ]
         err_lines = [
             'running...\n',
-            'The url to track the job: %s\n' % urls[0],
+            'The url to track the job: {0!s}\n'.format(urls[0]),
             'done\n',
             'running another stage...\n',
-            'The url to track the job: %s\n' % urls[1],
+            'The url to track the job: {0!s}\n'.format(urls[1]),
             'done\n',
             'running another stage...\n',
-            'The url to track the job: %s\n' % urls[2],
+            'The url to track the job: {0!s}\n'.format(urls[2]),
             'done\n',
         ]
         self._run_and_track(err_lines, 0)
@@ -464,7 +464,7 @@ class JobRunnerTest(unittest.TestCase):
     def test_tracking_url_captured_on_fail(self):
         url = 'http://tracking/'
         err_lines = [
-            'The url to track the job: %s\n' % url,
+            'The url to track the job: {0!s}\n'.format(url),
         ]
         with self.assertRaises(luigi.contrib.hadoop.HadoopJobError):
             self._run_and_track(err_lines, 1)
@@ -481,7 +481,7 @@ class JobRunnerTest(unittest.TestCase):
     def test_kill_job_on_interrupt(self):
         job_id = 'job_1234_5678'
         err_lines = [
-            'FlowStep: [SomeJob()] submitted hadoop job: %s\n' % job_id,
+            'FlowStep: [SomeJob()] submitted hadoop job: {0!s}\n'.format(job_id),
             'some other line\n',
         ]
         subprocess = self._run_and_track_with_interrupt(err_lines)
@@ -491,7 +491,7 @@ class JobRunnerTest(unittest.TestCase):
         job_id = 'job_1234_5678'
         err_lines = [
             'FlowStep: [SomeJob()] submitted hadoop job: job_0000_0000\n',
-            'FlowStep: [SomeJob()] submitted hadoop job: %s\n' % job_id,
+            'FlowStep: [SomeJob()] submitted hadoop job: {0!s}\n'.format(job_id),
             'some other line\n',
         ]
         subprocess = self._run_and_track_with_interrupt(err_lines)
@@ -500,7 +500,7 @@ class JobRunnerTest(unittest.TestCase):
     def test_kill_application_on_interrupt(self):
         application_id = 'application_1234_5678'
         err_lines = [
-            'YarnClientImpl: Submitted application %s\n' % application_id,
+            'YarnClientImpl: Submitted application {0!s}\n'.format(application_id),
             'FlowStep: [SomeJob()] submitted hadoop job: job_1234_5678\n',
         ]
         subprocess = self._run_and_track_with_interrupt(err_lines)
@@ -511,7 +511,7 @@ class JobRunnerTest(unittest.TestCase):
         err_lines = [
             'YarnClientImpl: Submitted application application_0000_0000\n',
             'FlowStep: [SomeJob()] submitted hadoop job: job_0000_0000\n',
-            'YarnClientImpl: Submitted application %s\n' % application_id,
+            'YarnClientImpl: Submitted application {0!s}\n'.format(application_id),
             'FlowStep: [SomeJob()] submitted hadoop job: job_1234_5678\n',
         ]
         subprocess = self._run_and_track_with_interrupt(err_lines)

--- a/test/contrib/hdfs_test.py
+++ b/test/contrib/hdfs_test.py
@@ -183,7 +183,7 @@ class HdfsAtomicWriteDirPipeTests(MiniClusterTestCase):
         pipe.close()
         self.assertTrue(hdfs.exists(self.path))
         dirlist = hdfs.listdir(self.path)
-        datapath = '%s/data' % self.path
+        datapath = '{0!s}/data'.format(self.path)
         returnlist = [d for d in dirlist]
         self.assertTrue(returnlist[0].endswith(datapath))
         pipe = hdfs.HdfsReadPipe(datapath)
@@ -308,7 +308,7 @@ class HdfsTargetTestMixin(FileSystemTargetTestMixin):
 
     def test_create_ancestors(self):
         parent = self._test_dir()
-        target = hdfs.HdfsTarget("%s/foo/bar/baz" % parent)
+        target = hdfs.HdfsTarget("{0!s}/foo/bar/baz".format(parent))
         if self.fs.exists(parent):
             self.fs.remove(parent, skip_trash=True)
         self.assertFalse(self.fs.exists(parent))
@@ -394,7 +394,7 @@ class HdfsTargetTestMixin(FileSystemTargetTestMixin):
         with t3.open('w') as f:
             f.write('biz\n')
 
-        files = hdfs.HdfsTarget("%s/part-0000*" % target_dir.path)
+        files = hdfs.HdfsTarget("{0!s}/part-0000*".format(target_dir.path))
 
         self.assertTrue(files.glob_exists(2))
         self.assertFalse(files.glob_exists(3))
@@ -406,7 +406,7 @@ class HdfsTargetTestMixin(FileSystemTargetTestMixin):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(text):
             msg = msg or "Regexp didn't match"
-            msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
+            msg = '{0!s}: {1!r} not found in {2!r}'.format(msg, expected_regexp.pattern, text)
             raise self.failureException(msg)
 
     def test_tmppath_not_configured(self):
@@ -485,7 +485,7 @@ class HdfsClientTest(MiniClusterTestCase):
     def test_put(self):
         local_dir = "test/data"
         local_filename = "file1.dat"
-        local_path = "%s/%s" % (local_dir, local_filename)
+        local_path = "{0!s}/{1!s}".format(local_dir, local_filename)
         target_path = self._test_dir()
 
         local_target = luigi.LocalTarget(local_path)
@@ -496,7 +496,7 @@ class HdfsClientTest(MiniClusterTestCase):
     def test_get(self):
         local_dir = "test/data"
         local_filename = "file1.dat"
-        local_path = "%s/%s" % (local_dir, local_filename)
+        local_path = "{0!s}/{1!s}".format(local_dir, local_filename)
         target_path = self._test_dir()
 
         local_target = luigi.LocalTarget(local_path)
@@ -504,7 +504,7 @@ class HdfsClientTest(MiniClusterTestCase):
         self.assertTrue(target.exists())
         local_target.remove()
 
-        local_copy_path = "%s/file1.dat.cp" % local_dir
+        local_copy_path = "{0!s}/file1.dat.cp".format(local_dir)
         local_copy = luigi.LocalTarget(local_copy_path)
         if local_copy.exists():
             local_copy.remove()
@@ -515,9 +515,9 @@ class HdfsClientTest(MiniClusterTestCase):
     def test_getmerge(self):
         local_dir = "test/data"
         local_filename1 = "file1.dat"
-        local_path1 = "%s/%s" % (local_dir, local_filename1)
+        local_path1 = "{0!s}/{1!s}".format(local_dir, local_filename1)
         local_filename2 = "file2.dat"
-        local_path2 = "%s/%s" % (local_dir, local_filename2)
+        local_path2 = "{0!s}/{1!s}".format(local_dir, local_filename2)
         target_dir = self._test_dir()
 
         local_target1 = luigi.LocalTarget(local_path1)
@@ -530,7 +530,7 @@ class HdfsClientTest(MiniClusterTestCase):
         self.assertTrue(target2.exists())
         local_target2.remove()
 
-        local_copy_path = "%s/file.dat.cp" % (local_dir)
+        local_copy_path = "{0!s}/file.dat.cp".format((local_dir))
         local_copy = luigi.LocalTarget(local_copy_path)
         if local_copy.exists():
             local_copy.remove()
@@ -538,7 +538,7 @@ class HdfsClientTest(MiniClusterTestCase):
         self.assertTrue(local_copy.exists())
         local_copy.remove()
 
-        local_copy_crc_path = "%s/.file.dat.cp.crc" % (local_dir)
+        local_copy_crc_path = "{0!s}/.file.dat.cp.crc".format((local_dir))
         local_copy_crc = luigi.LocalTarget(local_copy_crc_path)
         self.assertTrue(local_copy_crc.exists())
         local_copy_crc.remove()
@@ -549,27 +549,27 @@ class HdfsClientTest(MiniClusterTestCase):
         local_dir = "test/data"
 
         local_filename1 = "file1.dat"
-        local_path1 = "%s/%s" % (local_dir, local_filename1)
+        local_path1 = "{0!s}/{1!s}".format(local_dir, local_filename1)
         local_target1 = luigi.LocalTarget(local_path1)
         target1 = self.put_file(local_target1, local_filename1, target_dir)
         self.assertTrue(target1.exists())
 
         local_filename2 = "file2.dat"
-        local_path2 = "%s/%s" % (local_dir, local_filename2)
+        local_path2 = "{0!s}/{1!s}".format(local_dir, local_filename2)
         local_target2 = luigi.LocalTarget(local_path2)
         target2 = self.put_file(local_target2, local_filename2,
                                 target_dir, delpath=False)
         self.assertTrue(target2.exists())
 
         local_filename3 = "file3.dat"
-        local_path3 = "%s/%s" % (local_dir, local_filename3)
+        local_path3 = "{0!s}/{1!s}".format(local_dir, local_filename3)
         local_target3 = luigi.LocalTarget(local_path3)
         target3 = self.put_file(local_target3, local_filename3,
                                 target_dir + '/sub1')
         self.assertTrue(target3.exists())
 
         local_filename4 = "file4.dat"
-        local_path4 = "%s/%s" % (local_dir, local_filename4)
+        local_path4 = "{0!s}/{1!s}".format(local_dir, local_filename4)
         local_target4 = luigi.LocalTarget(local_path4)
         target4 = self.put_file(local_target4, local_filename4,
                                 target_dir + '/sub2')
@@ -585,11 +585,11 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=False,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(4, len(entries), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0], msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1], msg="%r" % entries)
-        self.assertEqual(path + '/sub1', entries[2], msg="%r" % entries)
-        self.assertEqual(path + '/sub2', entries[3], msg="%r" % entries)
+        self.assertEqual(4, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1', entries[2], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2', entries[3], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_files_only(self):
         """Verify we get the base two files created by _setup_listdir()"""
@@ -599,9 +599,9 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=False,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(2, len(entries), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0], msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1], msg="%r" % entries)
+        self.assertEqual(2, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_dirs_only(self):
         """Verify we get the base two directories created by _setup_listdir()"""
@@ -611,9 +611,9 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=False,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(2, len(entries), msg="%r" % entries)
-        self.assertEqual(path + '/sub1', entries[0], msg="%r" % entries)
-        self.assertEqual(path + '/sub2', entries[1], msg="%r" % entries)
+        self.assertEqual(2, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1', entries[0], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2', entries[1], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_recusion(self):
         """Verify we get the every item created by _setup_listdir()"""
@@ -623,13 +623,13 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=False,
                                   recursive=True)
         entries = [dd for dd in dirlist]
-        self.assertEqual(6, len(entries), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0], msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1], msg="%r" % entries)
-        self.assertEqual(path + '/sub1', entries[2], msg="%r" % entries)
-        self.assertEqual(path + '/sub1/file3.dat', entries[3], msg="%r" % entries)
-        self.assertEqual(path + '/sub2', entries[4], msg="%r" % entries)
-        self.assertEqual(path + '/sub2/file4.dat', entries[5], msg="%r" % entries)
+        self.assertEqual(6, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1', entries[2], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1/file3.dat', entries[3], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2', entries[4], msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2/file4.dat', entries[5], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_get_sizes(self):
         """Verify we get sizes for the two base files."""
@@ -639,13 +639,13 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=False,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(4, len(entries), msg="%r" % entries)
-        self.assertEqual(2, len(entries[0]), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0][0], msg="%r" % entries)
-        self.assertEqual(0, entries[0][1], msg="%r" % entries)
-        self.assertEqual(2, len(entries[1]), msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1][0], msg="%r" % entries)
-        self.assertEqual(0, entries[1][1], msg="%r" % entries)
+        self.assertEqual(4, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[0]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0][0], msg="{0!r}".format(entries))
+        self.assertEqual(0, entries[0][1], msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[1]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1][0], msg="{0!r}".format(entries))
+        self.assertEqual(0, entries[1][1], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_get_types(self):
         """Verify we get the types for the four base items."""
@@ -655,19 +655,19 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=True, include_time=False,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(4, len(entries), msg="%r" % entries)
-        self.assertEqual(2, len(entries[0]), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0][0], msg="%r" % entries)
-        self.assertTrue(re.match(r'[-f]', entries[0][1]), msg="%r" % entries)
-        self.assertEqual(2, len(entries[1]), msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1][0], msg="%r" % entries)
-        self.assertTrue(re.match(r'[-f]', entries[1][1]), msg="%r" % entries)
-        self.assertEqual(2, len(entries[2]), msg="%r" % entries)
-        self.assertEqual(path + '/sub1', entries[2][0], msg="%r" % entries)
-        self.assertEqual('d', entries[2][1], msg="%r" % entries)
-        self.assertEqual(2, len(entries[3]), msg="%r" % entries)
-        self.assertEqual(path + '/sub2', entries[3][0], msg="%r" % entries)
-        self.assertEqual('d', entries[3][1], msg="%r" % entries)
+        self.assertEqual(4, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[0]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0][0], msg="{0!r}".format(entries))
+        self.assertTrue(re.match(r'[-f]', entries[0][1]), msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[1]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1][0], msg="{0!r}".format(entries))
+        self.assertTrue(re.match(r'[-f]', entries[1][1]), msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[2]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1', entries[2][0], msg="{0!r}".format(entries))
+        self.assertEqual('d', entries[2][1], msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[3]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2', entries[3][0], msg="{0!r}".format(entries))
+        self.assertEqual('d', entries[3][1], msg="{0!r}".format(entries))
 
     def test_listdir_base_list_get_times(self):
         """Verify we get the times, even if we can't fully check them."""
@@ -677,9 +677,9 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=False, include_time=True,
                                   recursive=False)
         entries = [dd for dd in dirlist]
-        self.assertEqual(4, len(entries), msg="%r" % entries)
-        self.assertEqual(2, len(entries[0]), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0][0], msg="%r" % entries)
+        self.assertEqual(4, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(2, len(entries[0]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0][0], msg="{0!r}".format(entries))
 
     def test_listdir_full_list_get_everything(self):
         """Verify we get all the values, even if we can't fully check them."""
@@ -689,21 +689,21 @@ class HdfsClientTest(MiniClusterTestCase):
                                   include_type=True, include_time=True,
                                   recursive=True)
         entries = [dd for dd in dirlist]
-        self.assertEqual(6, len(entries), msg="%r" % entries)
-        self.assertEqual(4, len(entries[0]), msg="%r" % entries)
-        self.assertEqual(path + '/file1.dat', entries[0][0], msg="%r" % entries)
-        self.assertEqual(0, entries[0][1], msg="%r" % entries)
-        self.assertTrue(re.match(r'[-f]', entries[0][2]), msg="%r" % entries)
-        self.assertEqual(4, len(entries[1]), msg="%r" % entries)
-        self.assertEqual(path + '/file2.dat', entries[1][0], msg="%r" % entries)
-        self.assertEqual(4, len(entries[2]), msg="%r" % entries)
-        self.assertEqual(path + '/sub1', entries[2][0], msg="%r" % entries)
-        self.assertEqual(4, len(entries[3]), msg="%r" % entries)
-        self.assertEqual(path + '/sub1/file3.dat', entries[3][0], msg="%r" % entries)
-        self.assertEqual(4, len(entries[4]), msg="%r" % entries)
-        self.assertEqual(path + '/sub2', entries[4][0], msg="%r" % entries)
-        self.assertEqual(4, len(entries[5]), msg="%r" % entries)
-        self.assertEqual(path + '/sub2/file4.dat', entries[5][0], msg="%r" % entries)
+        self.assertEqual(6, len(entries), msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[0]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file1.dat', entries[0][0], msg="{0!r}".format(entries))
+        self.assertEqual(0, entries[0][1], msg="{0!r}".format(entries))
+        self.assertTrue(re.match(r'[-f]', entries[0][2]), msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[1]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/file2.dat', entries[1][0], msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[2]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1', entries[2][0], msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[3]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub1/file3.dat', entries[3][0], msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[4]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2', entries[4][0], msg="{0!r}".format(entries))
+        self.assertEqual(4, len(entries[5]), msg="{0!r}".format(entries))
+        self.assertEqual(path + '/sub2/file4.dat', entries[5][0], msg="{0!r}".format(entries))
 
     @mock.patch('luigi.contrib.hdfs.hadoopcli_clients.HdfsClient.call_check')
     def test_cdh3_client(self, call_check):
@@ -755,7 +755,7 @@ class _MiscOperationsMixin(object):
     # TODO: chown/chmod/count should really be methods on HdfsTarget rather than the client!
 
     def get_target(self):
-        fn = '/tmp/foo-%09d' % random.randint(0, 999999999)
+        fn = '/tmp/foo-{0:09d}'.format(random.randint(0, 999999999))
         t = luigi.contrib.hdfs.HdfsTarget(fn)
         with t.open('w') as f:
             f.write('test')

--- a/test/contrib/hive_test.py
+++ b/test/contrib/hive_test.py
@@ -290,7 +290,7 @@ class MyHiveTask(luigi.contrib.hive.HiveQueryTask):
     param = luigi.Parameter()
 
     def query(self):
-        return 'banana banana %s' % self.param
+        return 'banana banana {0!s}'.format(self.param)
 
 
 class TestHiveTask(unittest.TestCase):

--- a/test/contrib/redshift_test.py
+++ b/test/contrib/redshift_test.py
@@ -48,7 +48,7 @@ class DummyS3CopyToTable(luigi.contrib.redshift.S3CopyToTable):
     prune_date = ''
 
     def s3_load_path(self):
-        return 's3://%s/%s' % (BUCKET, KEY)
+        return 's3://{0!s}/{1!s}'.format(BUCKET, KEY)
 
 
 class DummyS3CopyToTempTable(DummyS3CopyToTable):
@@ -123,7 +123,7 @@ class TestS3CopyToTable(unittest.TestCase):
                                            .cursor
                                            .return_value)
         assert mock_cursor.execute.call_args_list[0][0][0].startswith(
-            "CREATE  TABLE %s" % task.table)
+            "CREATE  TABLE {0!s}".format(task.table))
 
         return
 
@@ -208,7 +208,7 @@ class DummyRedshiftUnloadTask(luigi.contrib.redshift.RedshiftUnloadTask):
     aws_access_key_id = 'AWS_ACCESS_KEY'
     aws_secret_access_key = 'AWS_SECRET_KEY'
 
-    s3_unload_path = 's3://%s/%s' % (BUCKET, KEY)
+    s3_unload_path = 's3://{0!s}/{1!s}'.format(BUCKET, KEY)
     unload_options = "DELIMITER ',' ADDQUOTES GZIP ALLOWOVERWRITE PARALLEL OFF"
 
     def query(self):

--- a/test/contrib/scalding_test.py
+++ b/test/contrib/scalding_test.py
@@ -35,7 +35,7 @@ class MyScaldingTask(scalding.ScaldingJobTask):
 
 class ScaldingTest(unittest.TestCase):
     def setUp(self):
-        self.scalding_home = os.path.join(tempfile.gettempdir(), 'scalding-%09d' % random.randint(0, 999999999))
+        self.scalding_home = os.path.join(tempfile.gettempdir(), 'scalding-{0:09d}'.format(random.randint(0, 999999999)))
         os.mkdir(self.scalding_home)
         self.lib_dir = os.path.join(self.scalding_home, 'lib')
         os.mkdir(self.lib_dir)

--- a/test/contrib/sqla_test.py
+++ b/test/contrib/sqla_test.py
@@ -38,7 +38,7 @@ if six.PY3:
 
 class BaseTask(luigi.Task):
 
-    TASK_LIST = ["item%d\tproperty%d\n" % (i, i) for i in range(10)]
+    TASK_LIST = ["item{0:d}\tproperty{1:d}\n".format(i, i) for i in range(10)]
 
     def output(self):
         return MockFile("BaseTask", mirror_on_stderr=True)
@@ -271,7 +271,7 @@ class TestSQLA(unittest.TestCase):
 
             def run(self):
                 out = self.output().open("w")
-                tasks = ["item%d,property%d\n" % (i, i) for i in range(10)]
+                tasks = ["item{0:d},property{1:d}\n".format(i, i) for i in range(10)]
                 for task in tasks:
                     out.write(task)
                 out.close()

--- a/test/contrib/test_ssh.py
+++ b/test/contrib/test_ssh.py
@@ -52,7 +52,7 @@ conn.sendall(b'hello')
 
 try:
     x = subprocess.check_output(
-        "ssh %s -S none -o BatchMode=yes 'echo 1'" % working_ssh_host,
+        "ssh {0!s} -S none -o BatchMode=yes 'echo 1'".format(working_ssh_host),
         shell=True
     )
     if x != b'1\n':
@@ -252,7 +252,7 @@ class TestRemoteTargetAtomicity(unittest.TestCase, target_test.FileSystemTargetT
 
 
 class TestRemoteTargetCreateDirectories(TestRemoteTargetAtomicity):
-    path = '/tmp/%s/xyz/luigi_remote_atomic_test.txt' % random.randint(0, 999999999)
+    path = '/tmp/{0!s}/xyz/luigi_remote_atomic_test.txt'.format(random.randint(0, 999999999))
 
 
 class TestRemoteTargetRelative(TestRemoteTargetAtomicity):

--- a/test/event_callbacks_test.py
+++ b/test/event_callbacks_test.py
@@ -172,7 +172,7 @@ class ConsistentMockOutput(object):
     param = luigi.IntParameter(default=1)
 
     def output(self):
-        return MockTarget('/%s/%u' % (self.__class__.__name__, self.param))
+        return MockTarget('/{0!s}/{1:d}'.format(self.__class__.__name__, self.param))
 
     def produce_output(self):
         with self.output().open('w') as o:

--- a/test/fib_test.py
+++ b/test/fib_test.py
@@ -34,7 +34,7 @@ class Fib(luigi.Task):
             return []
 
     def output(self):
-        return MockTarget('/tmp/fib_%d' % self.n)
+        return MockTarget('/tmp/fib_{0:d}'.format(self.n))
 
     def run(self):
         if self.n == 0:
@@ -48,7 +48,7 @@ class Fib(luigi.Task):
                     s += int(line.strip())
 
         f = self.output().open('w')
-        f.write('%d\n' % s)
+        f.write('{0:d}\n'.format(s))
         f.close()
 
 

--- a/test/file_test.py
+++ b/test/file_test.py
@@ -233,8 +233,8 @@ class LocalTargetTest(unittest.TestCase, FileSystemTargetTestMixin):
 
 
 class LocalTargetCreateDirectoriesTest(LocalTargetTest):
-    path = '/tmp/%s/xyz/test.txt' % random.randint(0, 999999999)
-    copy = '/tmp/%s/xyz_2/copy.txt' % random.randint(0, 999999999)
+    path = '/tmp/{0!s}/xyz/test.txt'.format(random.randint(0, 999999999))
+    copy = '/tmp/{0!s}/xyz_2/copy.txt'.format(random.randint(0, 999999999))
 
 
 class LocalTargetRelativeTest(LocalTargetTest):

--- a/test/lock_test.py
+++ b/test/lock_test.py
@@ -61,14 +61,14 @@ class LockTest(unittest.TestCase):
 
     def test_acquiring_taken_lock(self):
         with open(self.pid_file, 'w') as f:
-            f.write('%d\n' % (self.pid, ))
+            f.write('{0:d}\n'.format(self.pid ))
 
         acquired = luigi.lock.acquire_for(self.pid_dir)
         self.assertFalse(acquired)
 
     def test_acquiring_partially_taken_lock(self):
         with open(self.pid_file, 'w') as f:
-            f.write('%d\n' % (self.pid, ))
+            f.write('{0:d}\n'.format(self.pid ))
 
         acquired = luigi.lock.acquire_for(self.pid_dir, 2)
         self.assertTrue(acquired)
@@ -79,7 +79,7 @@ class LockTest(unittest.TestCase):
     def test_acquiring_lock_from_missing_process(self):
         fake_pid = 99999
         with open(self.pid_file, 'w') as f:
-            f.write('%d\n' % (fake_pid, ))
+            f.write('{0:d}\n'.format(fake_pid ))
 
         acquired = luigi.lock.acquire_for(self.pid_dir)
         self.assertTrue(acquired)
@@ -90,7 +90,7 @@ class LockTest(unittest.TestCase):
     @mock.patch('os.kill')
     def test_take_lock_with_kill(self, kill_fn):
         with open(self.pid_file, 'w') as f:
-            f.write('%d\n' % (self.pid,))
+            f.write('{0:d}\n'.format(self.pid))
 
         kill_signal = 77777
         acquired = luigi.lock.acquire_for(self.pid_dir, kill_signal=kill_signal)

--- a/test/minicluster.py
+++ b/test/minicluster.py
@@ -71,11 +71,11 @@ class MiniClusterTestCase(unittest.TestCase):
 
     @staticmethod
     def _test_dir():
-        return '/tmp/luigi_tmp_testdir_%s' % getpass.getuser()
+        return '/tmp/luigi_tmp_testdir_{0!s}'.format(getpass.getuser())
 
     @staticmethod
     def _test_file(suffix=""):
-        return '%s/luigi_tmp_testfile%s' % (MiniClusterTestCase._test_dir(), suffix)
+        return '{0!s}/luigi_tmp_testfile{1!s}'.format(MiniClusterTestCase._test_dir(), suffix)
 
 
 class MiniClusterHadoopJobRunner(luigi.contrib.hadoop.HadoopJobRunner):

--- a/test/parameter_test.py
+++ b/test/parameter_test.py
@@ -91,7 +91,7 @@ class BananaDep(luigi.Task):
     y = luigi.Parameter(default='def')
 
     def output(self):
-        return MockTarget('banana-dep-%s-%s' % (self.x, self.y))
+        return MockTarget('banana-dep-{0!s}-{1!s}'.format(self.x, self.y))
 
     def run(self):
         self.output().open('w').close()
@@ -115,7 +115,7 @@ class Banana(luigi.Task):
             raise Exception('unknown style')
 
     def output(self):
-        return MockTarget('banana-%s-%s' % (self.x, self.y))
+        return MockTarget('banana-{0!s}-{1!s}'.format(self.x, self.y))
 
     def run(self):
         self.output().open('w').close()

--- a/test/recursion_test.py
+++ b/test/recursion_test.py
@@ -28,7 +28,7 @@ class Popularity(luigi.Task):
     date = luigi.DateParameter(default=datetime.date.today() - datetime.timedelta(1))
 
     def output(self):
-        return MockTarget('/tmp/popularity/%s.txt' % self.date.strftime('%Y-%m-%d'))
+        return MockTarget('/tmp/popularity/{0!s}.txt'.format(self.date.strftime('%Y-%m-%d')))
 
     def requires(self):
         return Popularity(self.date - datetime.timedelta(1))

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -50,7 +50,7 @@ def generate_manifest_json(path_to_folders, file_names):
     for path_to_folder in path_to_folders:
         for file_name in file_names:
             entries.append({
-                'url': '%s/%s' % (path_to_folder, file_name),
+                'url': '{0!s}/{1!s}'.format(path_to_folder, file_name),
                 'mandatory': True
             })
     return {'entries': entries}
@@ -64,12 +64,12 @@ class TestRedshiftManifestTask(unittest.TestCase):
         bucket = client.s3.create_bucket(BUCKET)
         for key in FILES:
             k = Key(bucket)
-            k.key = '%s/%s' % (KEY, key)
+            k.key = '{0!s}/{1!s}'.format(KEY, key)
             k.set_contents_from_string('')
-        folder_path = 's3://%s/%s' % (BUCKET, KEY)
+        folder_path = 's3://{0!s}/{1!s}'.format(BUCKET, KEY)
         k = Key(bucket)
         k.key = 'manifest'
-        path = 's3://%s/%s/%s' % (BUCKET, k.key, 'test.manifest')
+        path = 's3://{0!s}/{1!s}/{2!s}'.format(BUCKET, k.key, 'test.manifest')
         folder_paths = [folder_path]
         t = redshift.RedshiftManifestTask(path, folder_paths)
         luigi.build([t], local_scheduler=True)
@@ -85,14 +85,14 @@ class TestRedshiftManifestTask(unittest.TestCase):
         for parent in [KEY, KEY_2]:
             for key in FILES:
                 k = Key(bucket)
-                k.key = '%s/%s' % (parent, key)
+                k.key = '{0!s}/{1!s}'.format(parent, key)
                 k.set_contents_from_string('')
-        folder_path_1 = 's3://%s/%s' % (BUCKET, KEY)
-        folder_path_2 = 's3://%s/%s' % (BUCKET, KEY_2)
+        folder_path_1 = 's3://{0!s}/{1!s}'.format(BUCKET, KEY)
+        folder_path_2 = 's3://{0!s}/{1!s}'.format(BUCKET, KEY_2)
         folder_paths = [folder_path_1, folder_path_2]
         k = Key(bucket)
         k.key = 'manifest'
-        path = 's3://%s/%s/%s' % (BUCKET, k.key, 'test.manifest')
+        path = 's3://{0!s}/{1!s}/{2!s}'.format(BUCKET, k.key, 'test.manifest')
         t = redshift.RedshiftManifestTask(path, folder_paths)
         luigi.build([t], local_scheduler=True)
 

--- a/test/scheduler_visualisation_test.py
+++ b/test/scheduler_visualisation_test.py
@@ -58,7 +58,7 @@ class FactorTask(luigi.Task):
         f.close()
 
     def output(self):
-        return luigi.LocalTarget(os.path.join(tempdir, 'luigi_test_factor_%d' % self.product))
+        return luigi.LocalTarget(os.path.join(tempdir, 'luigi_test_factor_{0:d}'.format(self.product)))
 
 
 class BadReqTask(luigi.Task):
@@ -500,9 +500,9 @@ class SchedulerVisualisationTest(unittest.TestCase):
         dep_graph = self._remote().inverse_dep_graph(X().task_id)
 
         def assert_has_deps(task_id, deps):
-            self.assertTrue(task_id in dep_graph, '%s not in dep_graph %s' % (task_id, dep_graph))
+            self.assertTrue(task_id in dep_graph, '{0!s} not in dep_graph {1!s}'.format(task_id, dep_graph))
             task = dep_graph[task_id]
-            self.assertEqual(sorted(task['deps']), sorted(deps), '%s does not have deps %s' % (task_id, deps))
+            self.assertEqual(sorted(task['deps']), sorted(deps), '{0!s} does not have deps {1!s}'.format(task_id, deps))
 
         assert_has_deps(X().task_id, [Y().task_id])
         assert_has_deps(Y().task_id, [Z(id=1).task_id, Z(id=2).task_id])

--- a/test/test_sigpipe.py
+++ b/test/test_sigpipe.py
@@ -60,7 +60,7 @@ class TestSigpipe(unittest.TestCase):
         p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
         counter = 1
         for line in p1:
-            self.assertEqual(line.decode('utf8'), "Welcome %i times\n" % counter)
+            self.assertEqual(line.decode('utf8'), "Welcome {0:d} times\n".format(counter))
             counter += 1
         p1.close()
         self.assertFalse(os.path.exists("/tmp/luigi_sigpipe.marker"))
@@ -88,7 +88,7 @@ class TestSubprocessException(unittest.TestCase):
             p1 = InputPipeProcessWrapper(["bash", "/tmp/luigi_test_sigpipe.sh"])
             counter = 1
             for line in p1:
-                self.assertEqual(line.decode('utf8'), "Welcome %i times\n" % counter)
+                self.assertEqual(line.decode('utf8'), "Welcome {0:d} times\n".format(counter))
                 counter += 1
             p1.close()
 

--- a/test/webhdfs_minicluster.py
+++ b/test/webhdfs_minicluster.py
@@ -51,7 +51,7 @@ class WebHdfsMiniCluster(MiniCluster):
         cmd = [self._hadoop_cmd, 'jar', hadoop_jar,
                'minicluster', '-nomr', '-format']
         if nnport:
-            cmd.extend(['-nnport', "%s" % nnport])
+            cmd.extend(['-nnport', "{0!s}".format(nnport)])
         if True:
             # luigi webhdfs version
             cmd.extend(['-Ddfs.webhdfs.enabled=true'])

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -89,7 +89,7 @@ class DynamicRequires(Task):
         with self.output().open('w') as f:
             for i, d in enumerate(dummy_targets):
                 for line in d.open('r'):
-                    print('%d: %s' % (i, line.strip()), file=f)
+                    print('{0:d}: {1!s}'.format(i, line.strip()), file=f)
 
 
 class DynamicRequiresOtherModule(Task):
@@ -719,7 +719,7 @@ class DynamicDependenciesTest(unittest.TestCase):
         # loop through output and verify
         f = t.output().open('r')
         for i in range(7):
-            self.assertEqual(f.readline().strip(), '%d: Done!' % i)
+            self.assertEqual(f.readline().strip(), '{0:d}: Done!'.format(i))
 
         self.assertTrue(time.time() - t0 < self.timeout)
 
@@ -768,7 +768,7 @@ class WorkerPingThreadTests(unittest.TestCase):
             time.sleep(0.1)  # yes, this is ugly but it's exactly what we need to test
         self.assertTrue(
             self._total_pings > 1,
-            msg="Didn't retry pings (%d pings performed)" % (self._total_pings,)
+            msg="Didn't retry pings ({0:d} pings performed)".format(self._total_pings)
         )
 
     def test_ping_thread_shutdown(self):
@@ -828,7 +828,7 @@ class WorkerEmailTest(LuigiTestCase):
             worker.add(a)
             self.assertEqual(self.waits, 2)  # should attempt to add it 3 times
             self.assertNotEqual(emails, [])
-            self.assertTrue(emails[0].find("Luigi: Framework error while scheduling %s" % (a,)) != -1)
+            self.assertTrue(emails[0].find("Luigi: Framework error while scheduling {0!s}".format(a)) != -1)
 
     @email_patch
     def test_complete_error(self, emails):
@@ -840,9 +840,9 @@ class WorkerEmailTest(LuigiTestCase):
         a = A()
         self.assertEqual(emails, [])
         self.worker.add(a)
-        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} failed scheduling".format(a)) != -1)
         self.worker.run()
-        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} failed scheduling".format(a)) != -1)
         self.assertFalse(a.has_run)
 
     @email_patch
@@ -855,7 +855,7 @@ class WorkerEmailTest(LuigiTestCase):
         a = A()
         self.assertEqual(emails, [])
         self.worker.add(a)
-        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} failed scheduling".format(a)) != -1)
         self.worker.run()
         self.assertFalse(a.has_run)
 
@@ -869,9 +869,9 @@ class WorkerEmailTest(LuigiTestCase):
         a = A()
         self.assertEqual(emails, [])
         self.worker.add(a)
-        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} failed scheduling".format(a)) != -1)
         self.worker.run()
-        self.assertTrue(emails[0].find("Luigi: %s failed scheduling" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} failed scheduling".format(a)) != -1)
         self.assertFalse(a.has_run)
 
     @email_patch
@@ -884,13 +884,13 @@ class WorkerEmailTest(LuigiTestCase):
         self.worker.add(a)
         self.assertEqual(emails, [])
         self.worker.run()
-        self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} FAILED".format(a)) != -1)
 
     @email_patch
     def test_task_process_dies(self, emails):
         a = SuicidalWorker(signal.SIGKILL)
         luigi.build([a], workers=2, local_scheduler=True)
-        self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} FAILED".format(a)) != -1)
         self.assertTrue(emails[0].find("died unexpectedly with exit code -9") != -1)
 
     @email_patch
@@ -903,7 +903,7 @@ class WorkerEmailTest(LuigiTestCase):
 
         a = A()
         luigi.build([a], workers=2, local_scheduler=True)
-        self.assertTrue(emails[0].find("Luigi: %s FAILED" % (a,)) != -1)
+        self.assertTrue(emails[0].find("Luigi: {0!s} FAILED".format(a)) != -1)
         self.assertTrue(emails[0].find("timed out and was terminated.") != -1)
 
     @with_config(dict(worker=dict(retry_external_tasks='true')))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:arturosaco:luigi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:arturosaco:luigi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
